### PR TITLE
fix: replace deprecated actions/upload-artifact

### DIFF
--- a/.github/actions/generate-plugin-zip/action.yml
+++ b/.github/actions/generate-plugin-zip/action.yml
@@ -17,7 +17,7 @@ runs:
 
     # Upload the plugin artifact as a ZIP file
     - name: Upload plugin artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{inputs.plugin_slug}}
         path: ${{github.workspace}}/${{inputs.plugin_slug}}


### PR DESCRIPTION
Upload artifact V3 doesn't work entirely - https://github.com/ithemes/solid-backups/actions/runs/13284714740.

I've replaced it with the last version: v4. The difference is described here - https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md. We are not affected because we upload a single archive per job.

I've tested, and everything works as expected - see https://github.com/ithemes/solid-backups/actions/runs/13285382679.